### PR TITLE
重构了番剧详情页适配状态栏高度部分代码，使用 WindowsInsets 进行适配

### DIFF
--- a/app/src/main/java/com/xyoye/dandanplay/ui/activities/anime/AnimeDetailActivity.java
+++ b/app/src/main/java/com/xyoye/dandanplay/ui/activities/anime/AnimeDetailActivity.java
@@ -14,7 +14,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import com.blankj.utilcode.util.ConvertUtils;
 import com.blankj.utilcode.util.StringUtils;
 import com.blankj.utilcode.util.ToastUtils;
 import com.bumptech.glide.Glide;
@@ -38,6 +37,8 @@ import com.xyoye.dandanplay.ui.weight.item.AnimeTagItem;
 import com.xyoye.dandanplay.utils.AppConfig;
 import com.xyoye.dandanplay.utils.CommonUtils;
 import com.xyoye.dandanplay.utils.interf.AdapterItem;
+import com.xyoye.dandanplay.utils.view.ViewUtils;
+import com.xyoye.dandanplay.utils.view.WindowUtils;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -124,13 +125,27 @@ public class AnimeDetailActivity extends BaseMvpActivity<AnimeDetailPresenter> i
 
     @Override
     public void initView() {
-        int statusBarHeight = ConvertUtils.dp2px(20);
-        toolBar.setPadding(0, statusBarHeight, 0, 0);
-        ViewGroup.LayoutParams toolbarParams = toolBar.getLayoutParams();
-        toolbarParams.height += statusBarHeight;
-        toolbarHeight = toolbarParams.height;
 
-        scrollableLayout.addHeadView(toolBar);
+        final boolean[] isAddHeader = {false};
+        WindowUtils.doOnApplyWindowInsets(toolBar, (v, padding, margin, insets) -> {
+            ViewGroup.LayoutParams layoutParams = toolBar.getLayoutParams();
+            toolBar.setPadding(toolBar.getPaddingLeft(), padding.getTop() + insets.getSystemWindowInsetTop(), toolBar.getPaddingRight(), toolBar.getPaddingBottom());
+            if (isAddHeader[0]) {
+                scrollableLayout.removeHeadView(toolBar);
+                isAddHeader[0] = false;
+            }
+            layoutParams.height = ViewGroup.LayoutParams.WRAP_CONTENT;
+            toolBar.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
+            toolBar.getLayoutParams().height = toolBar.getMeasuredHeight();
+            if (!isAddHeader[0]) {
+                scrollableLayout.addHeadView(toolBar);
+                isAddHeader[0] = true;
+            }
+
+            return insets;
+        });
+        WindowUtils.requestApplyInsetsWhenAttached(toolBar);
+
         toolBar.setBackgroundColor(CommonUtils.getResColor(0, R.color.theme_color));
         toolBar.setTitleTextColor(CommonUtils.getResColor(0, R.color.immutable_text_white));
 

--- a/app/src/main/java/com/xyoye/dandanplay/ui/activities/anime/AnimeDetailActivity.java
+++ b/app/src/main/java/com/xyoye/dandanplay/ui/activities/anime/AnimeDetailActivity.java
@@ -37,7 +37,6 @@ import com.xyoye.dandanplay.ui.weight.item.AnimeTagItem;
 import com.xyoye.dandanplay.utils.AppConfig;
 import com.xyoye.dandanplay.utils.CommonUtils;
 import com.xyoye.dandanplay.utils.interf.AdapterItem;
-import com.xyoye.dandanplay.utils.view.ViewUtils;
 import com.xyoye.dandanplay.utils.view.WindowUtils;
 
 import org.greenrobot.eventbus.EventBus;

--- a/app/src/main/java/com/xyoye/dandanplay/ui/weight/ScrollableLayout.java
+++ b/app/src/main/java/com/xyoye/dandanplay/ui/weight/ScrollableLayout.java
@@ -164,6 +164,16 @@ public class ScrollableLayout extends LinearLayout {
         }
     }
 
+    public void removeHeadView(View view) {
+        if (view instanceof ViewGroup){
+            ViewGroup.LayoutParams lp = view.getLayoutParams();
+            extraY += lp.height;
+        }else {
+            LayoutParams lp = (LayoutParams)view.getLayoutParams();
+            extraY += view.getMeasuredHeight() + lp.topMargin;
+        }
+    }
+
     public boolean isHeadTop() {
         return mCurY == minY;
     }

--- a/app/src/main/java/com/xyoye/dandanplay/utils/view/ViewUtils.java
+++ b/app/src/main/java/com/xyoye/dandanplay/utils/view/ViewUtils.java
@@ -1,0 +1,49 @@
+package com.xyoye.dandanplay.utils.view;
+
+import android.support.v4.view.ViewCompat;
+import android.view.View;
+
+public class ViewUtils {
+
+    public static void doOnAttach(View view, ActionListener listener) {
+        if (ViewCompat.isAttachedToWindow(view)) {
+            listener.onAction(view);
+        } else {
+            view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+                @Override
+                public void onViewAttachedToWindow(View view) {
+                    view.removeOnAttachStateChangeListener(this);
+                    listener.onAction(view);
+                }
+
+                @Override
+                public void onViewDetachedFromWindow(View view) {
+
+                }
+            });
+        }
+    }
+
+    public static void doOnDetach(View view, ActionListener listener) {
+        if (!ViewCompat.isAttachedToWindow(view)) {
+            listener.onAction(view);
+        } else {
+            view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+                @Override
+                public void onViewAttachedToWindow(View view) {
+
+                }
+
+                @Override
+                public void onViewDetachedFromWindow(View view) {
+                    view.removeOnAttachStateChangeListener(this);
+                    listener.onAction(view);
+                }
+            });
+        }
+    }
+
+    public interface ActionListener {
+        void onAction(View view);
+    }
+}

--- a/app/src/main/java/com/xyoye/dandanplay/utils/view/ViewUtils.java
+++ b/app/src/main/java/com/xyoye/dandanplay/utils/view/ViewUtils.java
@@ -17,7 +17,7 @@ public class ViewUtils {
                 }
 
                 @Override
-                public void onViewDetachedFromWindow(View view) { }
+                public void onViewDetachedFromWindow(View view) {}
             });
         }
     }
@@ -28,7 +28,7 @@ public class ViewUtils {
         } else {
             view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
                 @Override
-                public void onViewAttachedToWindow(View view) { }
+                public void onViewAttachedToWindow(View view) {}
 
                 @Override
                 public void onViewDetachedFromWindow(View view) {

--- a/app/src/main/java/com/xyoye/dandanplay/utils/view/ViewUtils.java
+++ b/app/src/main/java/com/xyoye/dandanplay/utils/view/ViewUtils.java
@@ -17,9 +17,7 @@ public class ViewUtils {
                 }
 
                 @Override
-                public void onViewDetachedFromWindow(View view) {
-
-                }
+                public void onViewDetachedFromWindow(View view) { }
             });
         }
     }
@@ -30,9 +28,7 @@ public class ViewUtils {
         } else {
             view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
                 @Override
-                public void onViewAttachedToWindow(View view) {
-
-                }
+                public void onViewAttachedToWindow(View view) { }
 
                 @Override
                 public void onViewDetachedFromWindow(View view) {

--- a/app/src/main/java/com/xyoye/dandanplay/utils/view/ViewUtils.java
+++ b/app/src/main/java/com/xyoye/dandanplay/utils/view/ViewUtils.java
@@ -17,6 +17,7 @@ public class ViewUtils {
                 }
 
                 @Override
+                @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
                 public void onViewDetachedFromWindow(View view) {}
             });
         }
@@ -28,6 +29,7 @@ public class ViewUtils {
         } else {
             view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
                 @Override
+                @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
                 public void onViewAttachedToWindow(View view) {}
 
                 @Override

--- a/app/src/main/java/com/xyoye/dandanplay/utils/view/WindowUtils.java
+++ b/app/src/main/java/com/xyoye/dandanplay/utils/view/WindowUtils.java
@@ -1,0 +1,100 @@
+package com.xyoye.dandanplay.utils.view;
+
+import android.os.Build;
+import android.support.v4.view.OnApplyWindowInsetsListener;
+import android.support.v4.view.ViewCompat;
+import android.support.v4.view.WindowInsetsCompat;
+import android.view.View;
+import android.view.ViewGroup;
+
+public class WindowUtils {
+
+    private final static InsetsListener topInsetsListener = (view, padding, margin, insets) -> {
+        view.setPadding(view.getPaddingLeft(),padding.top + insets.getSystemWindowInsetTop(),view.getPaddingRight(),view.getPaddingBottom());
+        return insets;
+    };
+
+    private final static InsetsListener bottomInsetsListener = (view, padding, margin, insets) -> {
+        view.setPadding(view.getPaddingLeft(),view.getPaddingTop(),view.getPaddingRight(),padding.bottom + insets.getSystemWindowInsetBottom());
+        return insets;
+    };
+
+    public static void fitWindowInsetsTop(View view) {
+        doOnApplyWindowInsets(view, topInsetsListener);
+    }
+
+    public static void fitWindowInsetsBottom(View view) {
+        doOnApplyWindowInsets(view, bottomInsetsListener);
+    }
+
+    public static void requestApplyInsetsWhenAttached(View view) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            ViewUtils.doOnAttach(view, View::requestApplyInsets);
+        }
+    }
+
+
+    public static void doOnApplyWindowInsets(View view, InsetsListener listener) {
+        Padding padding = new Padding(view.getPaddingLeft(), view.getPaddingTop(), view.getPaddingRight(), view.getPaddingBottom());
+        Padding margin;
+        ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
+        if (layoutParams instanceof ViewGroup.MarginLayoutParams) {
+            ViewGroup.MarginLayoutParams marginLayoutParams = ((ViewGroup.MarginLayoutParams) layoutParams);
+            margin = new Padding(marginLayoutParams.leftMargin, marginLayoutParams.topMargin, marginLayoutParams.rightMargin, marginLayoutParams.bottomMargin);
+        } else {
+            margin = new Padding(0, 0, 0, 0);
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsetsCompat) -> listener.onApplyWindowInsets(v, padding, margin, windowInsetsCompat));
+    }
+
+    public interface InsetsListener {
+        WindowInsetsCompat onApplyWindowInsets(View view, Padding padding, Padding margin, WindowInsetsCompat insets);
+    }
+
+    public static class Padding {
+        private int left;
+        private int right;
+        private int top;
+        private int bottom;
+
+        public Padding(int left, int top, int right, int bottom) {
+            setBottom(bottom);
+            setRight(right);
+            setTop(top);
+            setLeft(left);
+        }
+
+        public int getBottom() {
+            return bottom;
+        }
+
+        public void setBottom(int bottom) {
+            this.bottom = bottom;
+        }
+
+        public int getLeft() {
+            return left;
+        }
+
+        public void setLeft(int left) {
+            this.left = left;
+        }
+
+        public int getRight() {
+            return right;
+        }
+
+        public void setRight(int right) {
+            this.right = right;
+        }
+
+        public int getTop() {
+            return top;
+        }
+
+        public void setTop(int top) {
+            this.top = top;
+        }
+    }
+
+}

--- a/app/src/main/java/com/xyoye/dandanplay/utils/view/WindowUtils.java
+++ b/app/src/main/java/com/xyoye/dandanplay/utils/view/WindowUtils.java
@@ -1,7 +1,6 @@
 package com.xyoye.dandanplay.utils.view;
 
 import android.os.Build;
-import android.support.v4.view.OnApplyWindowInsetsListener;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.WindowInsetsCompat;
 import android.view.View;


### PR DESCRIPTION
原有的代码将高度写死为20dp，实际目前的 Android 机型存在不同高度的状态栏，且在分屏模式下的下方是不需要留出状态栏高度。重构了番剧详情页适配状态栏高度部分代码，使用 WindowsInsets 进行状态栏高度适配。