### PR TITLE
修复问题" magnet 包含 dn 参数时，种子文件名太长，系统无法创建种子文件"

### DIFF
--- a/app/src/main/java/com/xyoye/dandanplay/mvp/impl/SearchPresenterImpl.java
+++ b/app/src/main/java/com/xyoye/dandanplay/mvp/impl/SearchPresenterImpl.java
@@ -206,7 +206,11 @@ public class SearchPresenterImpl extends BaseMvpPresenterImpl<SearchView> implem
             public void onSuccess(ResponseBody responseBody) {
                 String downloadPath = getView().getDownloadFolder();
                 downloadPath += Constants.DefaultConfig.torrentFolder;
-                downloadPath += "/" + magnet.substring(20) + ".torrent";
+                int indexOfLast = magnet.indexOf("&dn");
+                if (indexOfLast < 0) {
+                    indexOfLast = magnet.length();
+                }
+                downloadPath += "/" + magnet.substring(20, indexOfLast) + ".torrent";
                 FileIOUtils.writeFileFromIS(downloadPath, responseBody.byteStream());
                 getView().dismissDownloadTorrentLoading();
                 getView().downloadTorrentOver(downloadPath, position, onlyDownload, playResource);


### PR DESCRIPTION
使用自定义节点时，部分自定义节点没有过滤dn参数，导致弹弹Play因为文件名太长而无法创建文件