### PR TITLE
[Bug修复]修复了远程访问在启用Token后无法下载图片与播放视频的问题

### DIFF
--- a/common_component/src/main/java/com/xyoye/common_component/utils/RemoteHelper.kt
+++ b/common_component/src/main/java/com/xyoye/common_component/utils/RemoteHelper.kt
@@ -18,18 +18,18 @@ class RemoteHelper private constructor() {
         val instance = RemoteHelper()
     }
 
-    fun buildImageUrl(hash: String): String {
-        var imageUrl = remoteUrl + "api/v1/image/$hash"
+    fun buildImageUrl(id: String): String {
+        var imageUrl = remoteUrl + "api/v1/image/id/$id"
         if (!remoteToken.isNullOrEmpty()) {
-            imageUrl += "&token=$remoteToken"
+            imageUrl += "?token=$remoteToken"
         }
         return imageUrl
     }
 
-    fun buildVideoUrl(hash: String): String {
-        var videoUrl = remoteUrl + "api/v1/stream/$hash"
+    fun buildVideoUrl(id: String): String {
+        var videoUrl = remoteUrl + "api/v1/stream/id/$id"
         if (!remoteToken.isNullOrEmpty()) {
-            videoUrl += "&token=$remoteToken"
+            videoUrl += "?token=$remoteToken"
         }
         return videoUrl
     }

--- a/stream_component/src/main/java/com/xyoye/stream_component/ui/activities/remote_file/RemoteFileViewModel.kt
+++ b/stream_component/src/main/java/com/xyoye/stream_component/ui/activities/remote_file/RemoteFileViewModel.kt
@@ -65,7 +65,7 @@ class RemoteFileViewModel : BaseViewModel() {
     fun openVideo(videoData: RemoteVideoData) {
         viewModelScope.launch {
             showLoading()
-            val videoUrl = RemoteHelper.getInstance().buildVideoUrl(videoData.Hash)
+            val videoUrl = RemoteHelper.getInstance().buildVideoUrl(videoData.Id)
             val playParams = PlayParams(
                 videoUrl,
                 (videoData.EpisodeTitle ?: videoData.Name).formatFileName(),

--- a/stream_component/src/main/java/com/xyoye/stream_component/ui/fragment/remote_file/RemoteFileFragment.kt
+++ b/stream_component/src/main/java/com/xyoye/stream_component/ui/fragment/remote_file/RemoteFileFragment.kt
@@ -96,7 +96,7 @@ class RemoteFileFragment : BaseFragment<RemoteFileFragmentViewModel, FragmentRem
                             if (data.Duration != null) {
                                 durationTv.text = formatDuration(data.Duration!! * 1000)
                             }
-                            val coverUrl = RemoteHelper.getInstance().buildImageUrl(data.Hash)
+                            val coverUrl = RemoteHelper.getInstance().buildImageUrl(data.Id)
                             coverIv.setGlideImage(coverUrl, 5)
 
                             danmuTipsTv.isVisible = isFileExist(data.danmuPath)


### PR DESCRIPTION
包含如下改动：
1. [Bug修复]修复了远程访问在启用Token后无法下载图片与播放视频的问题。之前版本错误拼接了url
2. [功能优化]远程访问中使用id代替hash定位文件。`/image/id/{id}` API是 `/image/{hash}` 的更新版本，能够更精确定位媒体库中的文件，避免了hash可能查找到多个相同文件的问题。