### PR TITLE
[功能优化]: 在远程媒体库列表中显示文件所属动画标题

### DIFF
--- a/data_component/src/main/java/com/xyoye/data_component/data/remote/RemoteVideoData.kt
+++ b/data_component/src/main/java/com/xyoye/data_component/data/remote/RemoteVideoData.kt
@@ -31,13 +31,11 @@ data class RemoteVideoData(
     @NullToEmptyString
     var absolutePath: String = "",
     var isFolder: Boolean = false,
+    var displayName: String = EpisodeTitle.ifEmpty { Name },
     var childData: MutableList<RemoteVideoData> = mutableListOf()
 ) : Parcelable {
 
-    fun getEpisodeName(): String{
-        return if (EpisodeTitle.isEmpty())
-            Name
-        else
-            EpisodeTitle
+    fun getEpisodeName(): String {
+        return EpisodeTitle.ifEmpty { Name }
     }
 }

--- a/stream_component/src/main/java/com/xyoye/stream_component/ui/activities/remote_file/RemoteFileActivity.kt
+++ b/stream_component/src/main/java/com/xyoye/stream_component/ui/activities/remote_file/RemoteFileActivity.kt
@@ -3,6 +3,7 @@ package com.xyoye.stream_component.ui.activities.remote_file
 import android.view.KeyEvent
 import android.view.Menu
 import android.view.MenuItem
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.alibaba.android.arouter.facade.annotation.Autowired
 import com.alibaba.android.arouter.facade.annotation.Route
 import com.alibaba.android.arouter.launcher.ARouter
@@ -165,7 +166,9 @@ class RemoteFileActivity : BaseActivity<RemoteFileViewModel, ActivityRemoteFileB
         pathList.find { it.isOpened }?.isOpened = false
         pathList.add(pathBean)
         pathAdapter.setData(pathList)
-
+        dataBinding.pathRv.apply {
+            (layoutManager as? LinearLayoutManager)?.scrollToPosition(pathList.lastIndex)
+        }
         val childFragment = RemoteFileFragment.newInstance(fileData)
         fragmentStack.push(childFragment)
         supportFragmentManager.addFragment(R.id.container, childFragment, path, true)

--- a/stream_component/src/main/java/com/xyoye/stream_component/ui/fragment/remote_file/RemoteFileFragment.kt
+++ b/stream_component/src/main/java/com/xyoye/stream_component/ui/fragment/remote_file/RemoteFileFragment.kt
@@ -77,7 +77,7 @@ class RemoteFileFragment : BaseFragment<RemoteFileFragmentViewModel, FragmentRem
         } ?: return
 
         (mAttachActivity as RemoteFileActivity).listFolder(
-            remoteVideoData.Name,
+            remoteVideoData.displayName,
             path,
             remoteVideoData.childData
         )

--- a/stream_component/src/main/java/com/xyoye/stream_component/ui/fragment/remote_file/RemoteFileFragmentViewModel.kt
+++ b/stream_component/src/main/java/com/xyoye/stream_component/ui/fragment/remote_file/RemoteFileFragmentViewModel.kt
@@ -54,7 +54,7 @@ class RemoteFileFragmentViewModel : BaseViewModel() {
                 StorageFileBean(
                     it.isFolder,
                     it.absolutePath,
-                    it.getEpisodeName(),
+                    it.displayName,
                     history?.danmuPath,
                     history?.subtitlePath,
                     history?.videoPosition ?: 0L,

--- a/stream_component/src/main/java/com/xyoye/stream_component/utils/remote/RemoteFileHelper.kt
+++ b/stream_component/src/main/java/com/xyoye/stream_component/utils/remote/RemoteFileHelper.kt
@@ -59,13 +59,51 @@ object RemoteFileHelper {
                 treeList.addAll(it.value)
             } else if (it.key != TAG_INVALID) {
                 val absolutePath = folderName + it.key + separator
+                val child = convertTreeData(it.value, absolutePath)
+                val displayName = child.run {
+                    var firstAnimeTitle: String? = null
+                    var firstAnimeId = 0
+                    var hasSecond = false
+                    for (i in 0 until child.size) {
+                        val item = get(i)
+                        if (item.isFolder.not() && item.AnimeId > 0 && item.AnimeTitle.isNotEmpty()) {
+                            when (firstAnimeTitle) {
+                                null -> {
+                                    firstAnimeTitle = item.AnimeTitle
+                                    firstAnimeId = item.AnimeId
+                                }
+                                else -> {
+                                    if (item.AnimeId != firstAnimeId) {
+                                        hasSecond = true
+                                        break
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (firstAnimeTitle != null && !hasSecond) {
+                        "$firstAnimeTitle ( ${it.key} )"
+                    } else {
+                        for (item in child) {
+                            if (!item.isFolder && item.AnimeTitle.isNotEmpty()) {
+                                item.displayName = if (item.EpisodeTitle.isNotEmpty()) {
+                                    "${item.AnimeTitle} - ${item.EpisodeTitle}"
+                                } else {
+                                    item.getEpisodeName()
+                                }
+                            }
+                        }
+                        it.key
+                    }
+                }
                 val videoBean = RemoteVideoData(
                     isFolder = true,
                     Name = it.key,
                     absolutePath = absolutePath,
                     //目录则递归获取子文件及子目录
-                    childData = convertTreeData(it.value, absolutePath)
+                    childData = child
                 )
+                videoBean.displayName = displayName
                 treeList.add(videoBean)
             }
         }


### PR DESCRIPTION
如果当前文件夹存在多个动画（如辉夜和相合之物）的文件，则每个文件显示它所属的动画标题（辉夜 - 集标题）；如果子项是文件夹，且子项的子文件都所属同一动画，则显示子文件所属的动画标题（如该文件夹仅包括辉夜的文件，文件夹名则显示辉夜，并在括号标注文件夹真实名字）
