### PR TITLE
[Bug修复](master): 修复调用intent播放器没有定位上次进度问题

### DIFF
--- a/common_component/src/main/java/com/xyoye/common_component/source/factory/StreamSourceFactory.kt
+++ b/common_component/src/main/java/com/xyoye/common_component/source/factory/StreamSourceFactory.kt
@@ -26,7 +26,8 @@ object StreamSourceFactory {
             history?.danmuPath,
             history?.episodeId ?: 0,
             history?.subtitlePath,
-            uniqueKey
+            uniqueKey,
+            builder.mediaType
         )
     }
 

--- a/common_component/src/main/java/com/xyoye/common_component/source/media/StreamMediaSource.kt
+++ b/common_component/src/main/java/com/xyoye/common_component/source/media/StreamMediaSource.kt
@@ -17,7 +17,8 @@ class StreamMediaSource(
     private var danmuPath: String?,
     private var episodeId: Int,
     private var subtitlePath: String?,
-    private val uniqueKey: String
+    private val uniqueKey: String,
+    private val mediaType: MediaType,
 ) : BaseVideoSource(index, videoSources) {
 
     override fun getVideoUrl(): String {
@@ -33,7 +34,7 @@ class StreamMediaSource(
     }
 
     override fun getMediaType(): MediaType {
-        return MediaType.STREAM_LINK
+        return mediaType
     }
 
     override fun getHttpHeader(): Map<String, String>? {

--- a/player_component/src/main/java/com/xyoye/player_component/ui/activities/player_intent/PlayerIntentViewModel.kt
+++ b/player_component/src/main/java/com/xyoye/player_component/ui/activities/player_intent/PlayerIntentViewModel.kt
@@ -50,7 +50,7 @@ class PlayerIntentViewModel : BaseViewModel() {
             showLoading()
             val mediaSource = VideoSourceFactory.Builder()
                 .setVideoSources(listOf(url))
-                .create(MediaType.STREAM_LINK)
+                .create(MediaType.OTHER_STORAGE)
             hideLoading()
 
             if (mediaSource == null) {

--- a/player_component/src/main/java/com/xyoye/player_component/ui/activities/player_intent/PlayerIntentViewModel.kt
+++ b/player_component/src/main/java/com/xyoye/player_component/ui/activities/player_intent/PlayerIntentViewModel.kt
@@ -50,7 +50,7 @@ class PlayerIntentViewModel : BaseViewModel() {
             showLoading()
             val mediaSource = VideoSourceFactory.Builder()
                 .setVideoSources(listOf(url))
-                .create(MediaType.OTHER_STORAGE)
+                .create(MediaType.STREAM_LINK)
             hideLoading()
 
             if (mediaSource == null) {


### PR DESCRIPTION
串流播放的 PlayHistoryEntity数据库存储的 MediaType  是  STREAM_LINK ，
但是PlayerIntent调用的 MediaType的却是OTHER_STORAGE，导致 getPlayHistory 的history是null
fix https://github.com/xyoye/DanDanPlayForAndroid/issues/122#issue-1192471117

测试bug `adb shell "am start -n com.xyoye.dandanplay/com.xyoye.player_component.ui.activities.player_intent.PlayerIntentActivity https://yun.66dm.net/SBDM/DeliciousPartyPrecure01.m3u8"`
