### PR TITLE
[功能优化]: 分别区分弹幕和字幕的上次打开文件夹

### DIFF
--- a/common_component/src/main/java/com/xyoye/common_component/config/AppConfigTable.kt
+++ b/common_component/src/main/java/com/xyoye/common_component/config/AppConfigTable.kt
@@ -46,6 +46,14 @@ object AppConfigTable {
     var commonlyFolder2: String? = null
 
     @MMKVFiled
+    //上次打开弹幕目录
+    var lastOpenDanmakuFolder: String? = null
+
+    @MMKVFiled
+    //上次打开字幕目录
+    var lastOpenSubtitleFolder: String? = null
+
+    @MMKVFiled
     //上次打开目录
     var lastOpenFolder: String? = null
 

--- a/player_component/src/main/java/com/xyoye/player/controller/setting/SwitchSourceView.kt
+++ b/player_component/src/main/java/com/xyoye/player/controller/setting/SwitchSourceView.kt
@@ -64,8 +64,17 @@ class SwitchSourceView(
             R.string.select_local_danmu.toResString()
         openDirectory(getDefaultOpenDirectory())
 
+        var lastOpenFolderPath = if (isSwitchSubtitle) {
+            AppConfig.getLastOpenSubtitleFolder()
+        } else {
+            AppConfig.getLastOpenDanmakuFolder()
+        }
+        if (lastOpenFolderPath == null) {
+            lastOpenFolderPath = AppConfig.getLastOpenFolder()
+        }
+
         mCommonDirectoryData.clear()
-        mCommonDirectoryData.addAll(getCommonDirectoryList())
+        mCommonDirectoryData.addAll(getCommonDirectoryList(lastOpenFolderPath))
         viewBinding.rvCommonFolder.setData(mCommonDirectoryData)
 
         viewBinding.removeTv.isVisible = isSwitchSubtitle.not()
@@ -221,6 +230,11 @@ class SwitchSourceView(
 
         File(data.filePath).parentFile?.absolutePath?.let {
             AppConfig.putLastOpenFolder(it)
+            if (mSettingViewType == SettingViewType.LOAD_SUBTITLE_SOURCE) {
+                AppConfig.putLastOpenSubtitleFolder(it)
+            } else {
+                AppConfig.putLastOpenDanmakuFolder(it)
+            }
         }
 
         if (mSettingViewType == SettingViewType.LOAD_SUBTITLE_SOURCE) {
@@ -323,7 +337,7 @@ class SwitchSourceView(
     /**
      * 获取常用目录列表
      */
-    private fun getCommonDirectoryList(): MutableList<FilePathBean> {
+    private fun getCommonDirectoryList(lastOpenFolderPath: String?): MutableList<FilePathBean> {
         val commonDirectoryList = mutableListOf<FilePathBean>()
 
         //常用目录1
@@ -342,7 +356,6 @@ class SwitchSourceView(
         commonDirectoryList.add(FilePathBean("默认目录", getDefaultOpenDirectory()))
 
         //上次打开目录
-        val lastOpenFolderPath = AppConfig.getLastOpenFolder()
         if (AppConfig.isLastOpenFolderEnable() && lastOpenFolderPath?.isNotEmpty() == true) {
             commonDirectoryList.add(FilePathBean("上次使用", lastOpenFolderPath))
         }


### PR DESCRIPTION
#### 场景
番剧自带外挂字幕，视频顶层目录为`X`，要使用的本地字幕文件在`X/外挂字幕/简体`，要使用的本地弹幕文件在应用默认目录下面
每次绑定字幕后绑定弹幕，上次目录被设置为弹幕所在的目录
刷到下一集继续绑定字幕时，需要重新切到视频目录再点两下
#### 行为变更和潜在风险
将弹幕和字幕的上次访问目录进行区分，只需要点一次上次打开目录即可
全新安装debug版，在实机（Android 13）上测试打开字幕/弹幕没有问题
因为签名不同，无法测试是否会影响旧版本配置文件