### PR TITLE
修复文件列表中最近播放记录显示的逻辑错误。

### DIFF
--- a/common_component/src/main/java/com/xyoye/common_component/utils/PlayHistoryUtils.kt
+++ b/common_component/src/main/java/com/xyoye/common_component/utils/PlayHistoryUtils.kt
@@ -1,9 +1,8 @@
 package com.xyoye.common_component.utils
 
 import com.xyoye.common_component.extension.toText
-import java.util.Date
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
+import java.text.SimpleDateFormat
+import java.util.*
 
 /**
  * Created by XYJ on 2021/2/8.
@@ -13,18 +12,28 @@ object PlayHistoryUtils {
     private val dayName = arrayOf("今天", "昨天", "前天")
 
     fun formatPlayTime(time: Date): String {
-        if (time.after(Date())) {
+        val currTime = System.currentTimeMillis()
+        if (time.time > currTime) {
             return time.toText("yyyy-MM-dd HH:mm")
         }
-
-        val playTime = time.time.toDuration(DurationUnit.MILLISECONDS)
-        val currentTime = System.currentTimeMillis().toDuration(DurationUnit.MILLISECONDS)
-
-        val intervalDay = currentTime.minus(playTime).toInt(DurationUnit.DAYS)
-        if (intervalDay in dayName.indices) {
-            return dayName[intervalDay] + " " + time.toText("HH:mm")
+        // get the timestamp of today's beginning.
+        val sdf = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
+        val dayStartDate = sdf.parse(sdf.format(currTime)) ?: return time.toText("yyyy-MM-dd HH:mm")
+        var dayStart = dayStartDate.time
+        // check if the given datetime matches dayName.
+        var offset = 0
+        while (offset < dayName.size) {
+            if (dayStart <= time.time) {
+                break
+            }
+            dayStart -= 24 * 60 * 60 * 1000
+            offset++
         }
-        return time.toText("yyyy-MM-dd HH:mm")
+        // offset will be 3(out of index) if not matches dayName.
+        return if (offset in dayName.indices) {
+            dayName[offset] + " " + time.toText("HH:mm")
+        } else {
+            time.toText("yyyy-MM-dd HH:mm")
+        }
     }
-
 }


### PR DESCRIPTION
修复文件列表中最近播放记录显示的逻辑错误。原本的错误逻辑基于时间差判断是否为同一日，会错误显示部分文件的播放时间。比如昨天18:00播放的视频，今天12:00时查看则会错误显示为“今天18:00”。调整后的逻辑会比较一日的00:00与播放时间，从而判断是否为同一日。