### PR TITLE
优化手动绑定弹幕/字幕功能

### DIFF
--- a/local_component/src/main/java/com/xyoye/local_component/ui/fragment/bind_danmu/BindDanmuSourceFragmentViewModel.kt
+++ b/local_component/src/main/java/com/xyoye/local_component/ui/fragment/bind_danmu/BindDanmuSourceFragmentViewModel.kt
@@ -89,6 +89,10 @@ class BindDanmuSourceFragmentViewModel : BaseViewModel() {
             hideLoading()
 
             _searchedAnimeFlow.emit(result)
+            // 自动选择第一个动画。
+            if (result.isNotEmpty()) {
+                _selectedAnimeFlow.emit(result[0])
+            }
         }
     }
 


### PR DESCRIPTION
原Issue：https://github.com/xyoye/DanDanPlayForAndroid/issues/225

添加以下功能：
1. 在目录页面手动搜索任一文件的弹幕/字幕后，为同一目录下的具有相似文件名的文件提供快速搜索功能；
2. 搜索弹幕后，自动选中动画列表中第一个动画。